### PR TITLE
Add NES/Famicom section with Battle City

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Discussion: https://github.com/CharlotteCross1998/awesome-game-decompilations/di
 # Consoles
 (Under construction)
 
+## NES / Famicom
+- [⚠️ Battle City](https://github.com/vgrichina/battlecity)
+
 ## GameBoy 
 - [Pokémon Gold (SpaceWorld Demo)](https://github.com/pret/pokegold-spaceworld)
 - [Pokémon Red](https://github.com/pret/pokered)


### PR DESCRIPTION
Adds a **NES / Famicom** section with [Battle City](https://github.com/vgrichina/battlecity) — annotated 6502 disassembly + browser reimplementation of Namco's 1985 Famicom title.

The repo includes:
- 6502 disassembler (`dis.py`) reading a 249-entry `labels.csv`
- Master RE document ([`REVERSE.md`](https://github.com/vgrichina/battlecity/blob/main/REVERSE.md)) with full data-range map (~80% of PRG mapped: NMI, palette, entity tables, AI, hi-score entry, result screen, sound, construction mode)
- Asset extractors for CHR tiles, all 35 stage layouts, enemy spawn tables, and palettes
- Playable web port at https://battle-city.berrry.app

Marked with ⚠️ per the AI disclosure policy.