### PR TITLE
Add Star Fox Adventures to Gamecube

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Discussion: https://github.com/CharlotteCross1998/awesome-game-decompilations/di
 - [Animal Crossing](https://github.com/acreteam/ac-decomp)
 - [Animal Forest e+](https://github.com/acreteam/afe-decomp)
 - [Pokémon XD: Gale of Darkness](https://github.com/TeamOrre/xd-decomp)
+- [⚠️ Star Fox Adventures](https://github.com/zcanann/SFA-Decomp)
 - [⚠️ The Sims 2](https://github.com/natebag/Sims2DECOMP)
 - [The Legend of Zelda: Twilight Princess](https://github.com/zeldaret/tp)
 - [The Legend of Zelda: Wind Waker](https://github.com/zeldaret/tww)


### PR DESCRIPTION
Adds the [Star Fox Adventures](https://github.com/zcanann/SFA-Decomp) GameCube decompilation to the **Gamecube** section, in alphabetical order.

Marked with ⚠️ per the AI-disclosure policy, as the project uses AI assistance.
